### PR TITLE
Class for GitHub API

### DIFF
--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -20,10 +20,9 @@ namespace wp_kb_articles // Root namespace.
 		 */
 		class github_api extends abs_base
 		{
+			protected $owner, $repo, $branch = 'HEAD';
 
-			private $owner, $repo, $branch = 'HEAD';
-
-			private $api_key, $username, $password;
+			protected $api_key, $username, $password;
 
 			/**
 			 * Class constructor.

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -171,21 +171,19 @@ namespace wp_kb_articles // Root namespace.
 			}
 
 			/**
-			 * Retrieves UTF-8 encoded file from GitHub via SHA1 key
+			 * Retrieves UTF-8 encoded file from GitHub via SHA1 key.
 			 *
-			 * @param string $sha SHA1 value to be retrieved from the GitHub repo
+			 * @param string $sha SHA1 value to be retrieved from the GitHub repo.
 			 *
-			 * @return string|false FALSE on error, else string body from GitHub
+			 * @return string|boolean String body from GitHub, else `FALSE` on error.
 			 */
 			protected function retrieve_blob($sha)
 			{
-				$url = 'api.github.com/repos/%1$s/%2$s/git/blobs/%3$s';
-				$url = sprintf($url, $this->owner, $this->repo, $sha);
-
+				$url      = 'api.github.com/repos/%1$s/%2$s/git/blobs/%3$s';
+				$url      = sprintf($url, $this->owner, $this->repo, $sha);
 				$response = $this->get_response($url);
 
-				if($response) return json_decode($response['body'], TRUE);
-				else return FALSE;
+				return $response ? json_decode($response['body'], TRUE) : FALSE;
 			}
 
 			/**

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -20,9 +20,60 @@ namespace wp_kb_articles // Root namespace.
 		 */
 		class github_api extends abs_base
 		{
-			protected $owner, $repo, $branch = 'HEAD';
 
-			protected $api_key, $username, $password;
+			/**
+			 * Repo owner; e.g. `https://github.com/[owner]`.
+			 *
+			 * @since 141111 First documented version.
+			 *
+			 * @var string Repo owner; e.g. `https://github.com/[owner]`.
+			 */
+			protected $owner;
+
+			/**
+			 * Repo name; e.g. `https://github.com/[owner]/[repo]`.
+			 *
+			 * @since 141111 First documented version.
+			 *
+			 * @var string Repo name; e.g. `https://github.com/[owner]/[repo]`.
+			 */
+			protected $repo;
+
+			/**
+			 * Repo owner; e.g. `https://github.com/[owner]/[repo]/[branch]`.
+			 *
+			 * @since 141111 First documented version.
+			 *
+			 * @var string Repo owner; e.g. `https://github.com/[owner]/[repo]/[branch]`.
+			 */
+			protected $branch;
+
+			/**
+			 * API key; e.g. `Authorization: token [api_key]`.
+			 *
+			 * @since 141111 First documented version.
+			 *
+			 * @var string API key; e.g. `Authorization: token [api_key]`.
+			 */
+			protected $api_key;
+
+			/**
+			 * GitHub username; e.g. `https://[username]@github.com/`.
+			 *
+			 * @since 141111 First documented version.
+			 *
+			 * @var string GitHub username; e.g. `https://[username]@github.com/`.
+			 */
+			protected $username;
+
+			/**
+			 * GitHub password or API key; e.g. `https://[username]:[password]@github.com/`.
+			 *
+			 * @since 141111 First documented version.
+			 *
+			 * @var string GitHub password or API key; e.g. `https://[username]:[password]@github.com/`.
+			 */
+			protected $password;
 
 			/**
 			 * Class constructor.

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -221,7 +221,6 @@ namespace wp_kb_articles // Root namespace.
 					'headers' => array(),
 					'body'    => '',
 				);
-
 				// Normalize line breaks. Use "\n" for all line breaks.
 				$article = str_replace(array("\r\n", "\r"), "\n", $article);
 				$article = trim($article);
@@ -231,7 +230,6 @@ namespace wp_kb_articles // Root namespace.
 					$parts['body'] = $article;
 					return $parts;
 				}
-
 				$article_parts = preg_split('/^\-{3}$/m', $article, 3);
 
 				// If the article does NOT have three parts, it contains no YAML front matter.
@@ -240,7 +238,6 @@ namespace wp_kb_articles // Root namespace.
 					$parts['body'] = $article;
 					return $parts;
 				}
-
 				list(, $article_headers_part, $article_body_part) = $article_parts;
 
 				foreach(explode("\n", trim($article_headers_part)) as $_line)

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * GitHub API Class
+ *
+ * @since 141228 First documented version.
+ * @copyright WebSharks, Inc. <http://www.websharks-inc.com>
+ * @license GNU General Public License, version 3
+ */
+namespace wp_kb_articles // Root namespace.
+{
+	if(!defined('WPINC')) // MUST have WordPress.
+		exit('Do NOT access this file directly: '.basename(__FILE__));
+
+	if(!class_exists('\\'.__NAMESPACE__.'\\github_api'))
+	{
+		/**
+		 * GitHub Processor
+		 *
+		 * @since 141111 First documented version.
+		 */
+		class github_api extends abs_base
+		{
+			/**
+			 * Class constructor.
+			 *
+			 * @since 141111 First documented version.
+			 */
+			public function __construct()
+			{
+				parent::__construct();
+			}
+		}
+	}
+}

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -79,6 +79,9 @@ namespace wp_kb_articles // Root namespace.
 
 								foreach($lines as $line)
 								{
+									// In case of blank line or line without colon after at least 1 characters
+									if(!strlen($line) || strpos($line, ':', 1) === FALSE) continue;
+
 									list($name, $value) = explode(':', $line, 2);
 									$post['headers'][trim($name)] = trim($value);
 								}

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -189,21 +189,19 @@ namespace wp_kb_articles // Root namespace.
 			}
 
 			/**
-			 * Retrieves a UTF-8 encoded raw file from GitHub via path
+			 * Retrieves a UTF-8 encoded raw file from GitHub via path.
 			 *
-			 * @param string $path The path to the file to be retrieved
+			 * @param string $path The path to the file to be retrieved.
 			 *
-			 * @return string|false FALSE on error, else string body from GitHub
+			 * @return string|boolean String body from GitHub, else `FALSE` on error.
 			 */
 			protected function retrieve_file($path)
 			{
-				$url = 'raw.githubusercontent.com/%1$s/%2$s/%3$s/%4$s';
-				$url = sprintf($url, $this->owner, $this->repo, $this->branch, $path);
-
+				$url      = 'raw.githubusercontent.com/%1$s/%2$s/%3$s/%4$s';
+				$url      = sprintf($url, $this->owner, $this->repo, $this->branch, $path);
 				$response = $this->get_response($url);
 
-				if($response) return $response['body'];
-				return FALSE;
+				return $response ? $response['body'] : FALSE;
 			}
 
 			/**
@@ -261,8 +259,8 @@ namespace wp_kb_articles // Root namespace.
 			/**
 			 * Universal GitHub HTTP request method.
 			 *
-			 * @param string $url The URL to request
-			 * @param array  $args An associative array of arguments that can be used to overwrite the defaults used by the function
+			 * @param string $url The URL to request.
+			 * @param array  $args An associative array of arguments that can be used to overwrite the defaults used by the function.
 			 *
 			 * @return array|boolean An array with the following elements; else `FALSE` on error.
 			 *

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -52,7 +52,8 @@ namespace wp_kb_articles // Root namespace.
 
 				foreach($args as $_key => $_value)
 				{
-					if(empty($_value)) continue;
+					if(!$_value)
+						continue;
 
 					switch($_key)
 					{

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -44,38 +44,19 @@ namespace wp_kb_articles // Root namespace.
 
 					'username' => '',
 					'password' => '',
-
 					'api_key'  => '',
 				);
 				$args         = array_merge($default_args, $args);
 				$args         = array_intersect_key($args, $default_args);
 
-				foreach($args as $_key => $_value)
-				{
-					if(!$_value)
-						continue;
+				$this->owner = trim(strtolower((string)$args['owner']));
+				$this->repo  = trim(strtolower((string)$args['repo']));
 
-					switch($_key)
-					{
-						case 'password':
-						case 'api_key':
-							if(isset($args['username']) && !empty($args['username']))
-							{
-								$this->username = strtolower(trim((string)$args['username']));
-								$this->password = trim((string)$_value);
-							}
-							break;
-						case 'owner':
-							$this->owner = strtolower(trim($_value));
-							break;
-						case 'repo':
-							$this->repo = strtolower(trim($_value));
-							break;
-						case 'branch':
-							$this->branch = trim($_value);
-							break;
-					}
-				}
+				$this->branch = trim((string)$args['branch']);
+
+				$this->username = trim(strtolower((string)$args['username']));
+				$this->password = trim((string)$args['password']);
+				$this->api_key  = trim((string)$args['api_key']);
 			}
 
 			/* === Public Methods === */

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -116,7 +116,7 @@ namespace wp_kb_articles // Root namespace.
 			 *
 			 * @since 141111 First documented version.
 			 *
-			 * @param bool $get_body If TRUE, this function will retrieve body contents for each `.md` file in the request
+			 * @param bool $get_body If TRUE, this function will retrieve body contents for each `.md` file in the request.
 			 *
 			 * @return array|false
 			 */
@@ -125,48 +125,59 @@ namespace wp_kb_articles // Root namespace.
 				$tree  = $this->retrieve_tree();
 				$posts = array();
 
-				if(!$tree) return FALSE; // Error
+				if(!$tree)
+					return FALSE; // Error.
 
 				foreach($tree['tree'] as $blob)
 				{
-					if($blob['type'] !== 'blob') continue;
-					if(!preg_match('/\.md$/i', $blob['path'])) continue;
+					if($blob['type'] !== 'blob')
+						continue;
 
-					$post = array('headers' => array(), 'body' => '', 'sha' => $blob['sha'], 'url' => $blob['url'], 'path' => $blob['path']);
+					if(!preg_match('/\.md$/i', $blob['path']))
+						continue;
 
+					$post = array(
+						'headers' => array(),
+						'body'    => '',
+						'sha'     => $blob['sha'],
+						'url'     => $blob['url'],
+						'path'    => $blob['path']
+					);
 					if($get_body)
 					{
 						$body = $this->retrieve_body($post['sha']);
 
-						if(!$body) return FALSE; // TODO error handling
+						if(!$body) // TODO error handling.
+							return FALSE;
 
 						$post = array_merge_recursive($post, $this->parse_article($body));
 					}
-
 					$posts[$post['path']] = $post;
 				}
-
 				return $posts;
 			}
 
 			/**
-			 * Retrieves an associative array for information on a particular article, including the body.
+			 * Retrieves an associative array of information on a particular article, including the body.
 			 *
 			 * @since 141111 First documented version.
 			 *
-			 * @param string $a SHA1 key or path to file
+			 * @param string $a SHA1 key or path to file.
 			 *
-			 * @return array|false
+			 * @return array|boolean Array with the following elements, else `FALSE` on failure.
+			 *
+			 *    - `sha` SHA1 of the current body content data.
+			 *    - `headers` An associative array of all YAML headers.
+			 *    - `body` The body part of the article after YAML headers were parsed.
 			 */
 			public function retrieve_article($a)
 			{
-				$data = $this->retrieve_body($a);
+				if(!($body = $this->retrieve_body($a)))
+					return FALSE; // Error.
 
-				if(!$data) return FALSE;
+				$post = array('sha' => sha1($body));
 
-				$post = array('sha' => sha1($data));
-
-				return array_merge_recursive($post, $this->parse_article($data));
+				return array_merge($post, $this->parse_article($body));
 			}
 
 			/* === Base GitHub Retrieval === */
@@ -254,6 +265,7 @@ namespace wp_kb_articles // Root namespace.
 			 * @param string $article Input article content to parse.
 			 *
 			 * @return array An array with two elements.
+			 *
 			 *    - `headers` An associative array of all YAML headers.
 			 *    - `body` The body part of the article after YAML headers were parsed.
 			 */

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -39,7 +39,7 @@ namespace wp_kb_articles // Root namespace.
 
 			/* === Main Retrieval === */
 
-			public function retrieve_files($get_body = FALSE)
+			public function retrieve_posts($get_body = FALSE)
 			{
 				$tree  = $this->retrieve_tree();
 				$posts = array();
@@ -92,6 +92,17 @@ namespace wp_kb_articles // Root namespace.
 				return $posts;
 			}
 
+			public function retrieve_post($a)
+			{
+				$data = $this->retrieve_body($a);
+
+				if(!$data) return FALSE;
+
+				return $data;
+			}
+
+			/* === Base GitHub Retrieval === */
+
 			public function retrieve_body($a)
 			{
 				$is_sha = (bool)preg_match('/^[0-9a-f]{40}$/i', $a);
@@ -107,8 +118,6 @@ namespace wp_kb_articles // Root namespace.
 				else// It's a path
 					return $this->retrieve_file($a);
 			}
-
-			/* === Base GitHub Retrieval === */
 
 			public function retrieve_tree()
 			{

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -46,7 +46,7 @@ namespace wp_kb_articles // Root namespace.
 
 				$response = $this->get_response($url);
 
-				if($response['status_code'] === 200) return $response['body'];
+				if($response['status_code'] === 200) return json_decode($response['body'], TRUE);
 				else return FALSE;
 			}
 
@@ -57,7 +57,7 @@ namespace wp_kb_articles // Root namespace.
 
 				$response = $this->get_response($url);
 
-				if($response['status_code'] === 200) return $response['body'];
+				if($response['status_code'] === 200) return json_decode($response['body'], TRUE);
 				else return FALSE;
 			}
 

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -30,7 +30,7 @@ namespace wp_kb_articles // Root namespace.
 			 *
 			 * @since 141111 First documented version.
 			 *
-			 * @param array $args Array of arguments specific to the GitHub integration about to be executed. Required.
+			 * @param array $args Array of arguments specific to the GitHub integration.
 			 */
 			public function __construct(array $args)
 			{
@@ -80,7 +80,9 @@ namespace wp_kb_articles // Root namespace.
 			/* === Public Methods === */
 
 			/**
-			 * Retrieves an array of data for all `.MD` files within a repo
+			 * Retrieves an array of data for all `.MD` files within a repo.
+			 *
+			 * @since 141111 First documented version.
 			 *
 			 * @param bool $get_body If TRUE, this function will retrieve body contents for each `.md` file in the request
 			 *
@@ -116,7 +118,9 @@ namespace wp_kb_articles // Root namespace.
 			}
 
 			/**
-			 * Retrieves an associative array for information on a particular article, including the body
+			 * Retrieves an associative array for information on a particular article, including the body.
+			 *
+			 * @since 141111 First documented version.
 			 *
 			 * @param string $a SHA1 key or path to file
 			 *
@@ -136,7 +140,9 @@ namespace wp_kb_articles // Root namespace.
 			/* === Base GitHub Retrieval === */
 
 			/**
-			 * Wrapper function for retrieve_blob and retrieve_file based on $a
+			 * Wrapper function for retrieve_blob and retrieve_file based on `$a`.
+			 *
+			 * @since 141111 First documented version.
 			 *
 			 * @param string $a SHA1 key or path to file
 			 *
@@ -161,6 +167,8 @@ namespace wp_kb_articles // Root namespace.
 			/**
 			 * Retrieves list of files (as in, directory list) recursively from GitHub repo.
 			 *
+			 * @since 141111 First documented version.
+			 *
 			 * @return array|boolean Array of files from GitHub, else `FALSE` on error.
 			 */
 			protected function retrieve_tree()
@@ -174,6 +182,8 @@ namespace wp_kb_articles // Root namespace.
 
 			/**
 			 * Retrieves UTF-8 encoded file from GitHub via SHA1 key.
+			 *
+			 * @since 141111 First documented version.
 			 *
 			 * @param string $sha SHA1 value to be retrieved from the GitHub repo.
 			 *
@@ -191,6 +201,8 @@ namespace wp_kb_articles // Root namespace.
 			/**
 			 * Retrieves a UTF-8 encoded raw file from GitHub via path.
 			 *
+			 * @since 141111 First documented version.
+			 *
 			 * @param string $path The path to the file to be retrieved.
 			 *
 			 * @return string|boolean String body from GitHub, else `FALSE` on error.
@@ -206,6 +218,8 @@ namespace wp_kb_articles // Root namespace.
 
 			/**
 			 * Parses a KB article w/ possible YAML front matter.
+			 *
+			 * @since 141111 First documented version.
 			 *
 			 * @param string $article Input article content to parse.
 			 *
@@ -258,6 +272,8 @@ namespace wp_kb_articles // Root namespace.
 
 			/**
 			 * Universal GitHub HTTP request method.
+			 *
+			 * @since 141111 First documented version.
 			 *
 			 * @param string $url The URL to request.
 			 * @param array  $args An associative array of arguments that can be used to overwrite the defaults used by the function.

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -18,7 +18,7 @@ namespace wp_kb_articles // Root namespace.
 		 *
 		 * @since 141111 First documented version.
 		 */
-		class github_api extends abs_base
+		class github_api/* extends abs_base*/
 		{
 
 			private $owner, $repo, $branch = 'HEAD';
@@ -34,12 +34,12 @@ namespace wp_kb_articles // Root namespace.
 			 */
 			public function __construct()
 			{
-				parent::__construct();
+				//parent::__construct();
 			}
 
 			/* === Main Retrieval === */
 
-			public function retrieve_files()
+			public function retrieve_files($get_body = FALSE)
 			{
 				$tree  = $this->retrieve_tree();
 				$posts = array();
@@ -52,19 +52,26 @@ namespace wp_kb_articles // Root namespace.
 					if(!preg_match('/\.md$/i', $blob['path'])) continue;
 
 					$post = array('headers' => array(), 'body' => '', 'sha' => $blob['sha'], 'url' => $blob['url'], 'path' => $blob['path']);
-					$blob = $this->retrieve_blob($post['sha']);
 
-					if(!$blob) return FALSE; // TODO error handling
+					if($get_body)
+					{
+						$blob = $this->retrieve_blob($post['sha']);
 
-					$body = base64_decode($blob['body']);
+						if(!$blob) return FALSE; // TODO error handling
 
-					if(!strpos(trim($body), '---')) {
-						$post['body'] = $body;
-						$posts[$post['path']] = $post;
+						$body = base64_decode($blob['body']);
+
+						if(!strpos(trim($body), '---'))
+						{
+							$post['body']         = $body;
+						}
+						else
+						{
+							$yaml = yaml_parse($body, 0);
+						}
 					}
-					else {
 
-					}
+					$posts[$post['path']] = $post;
 				}
 
 				return $posts;

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -155,19 +155,17 @@ namespace wp_kb_articles // Root namespace.
 			}
 
 			/**
-			 * Retrieves list of files (as in, directory list) recursively from GitHub repo
+			 * Retrieves list of files (as in, directory list) recursively from GitHub repo.
 			 *
-			 * @return array|false FALSE on error, else array of files from GitHub
+			 * @return array|boolean Array of files from GitHub, else `FALSE` on error.
 			 */
 			protected function retrieve_tree()
 			{
-				$url = 'api.github.com/repos/%1$s/%2$s/git/trees/%3$s?recursive=1';
-				$url = sprintf($url, $this->owner, $this->repo, $this->branch);
-
+				$url      = 'api.github.com/repos/%1$s/%2$s/git/trees/%3$s?recursive=1';
+				$url      = sprintf($url, $this->owner, $this->repo, $this->branch);
 				$response = $this->get_response($url);
 
-				if($response) return json_decode($response['body'], TRUE);
-				else return FALSE;
+				return $response ? json_decode($response['body'], TRUE) : FALSE;
 			}
 
 			/**

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -80,7 +80,7 @@ namespace wp_kb_articles // Root namespace.
 								foreach($lines as $line)
 								{
 									// In case of blank line or line without colon after at least 1 characters
-									if(!strlen($line) || strpos($line, ':', 1) === FALSE) continue;
+									if(!isset($line[0]) || strpos($line, ':', 1) === FALSE) continue;
 
 									list($name, $value) = explode(':', $line, 2);
 									$post['headers'][trim($name)] = trim($value);

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -18,7 +18,7 @@ namespace wp_kb_articles // Root namespace.
 		 *
 		 * @since 141111 First documented version.
 		 */
-		class github_api/* extends abs_base*/
+		class github_api extends abs_base
 		{
 
 			private $owner, $repo, $branch = 'HEAD';
@@ -34,7 +34,7 @@ namespace wp_kb_articles // Root namespace.
 			 */
 			public function __construct()
 			{
-				//parent::__construct();
+				parent::__construct();
 			}
 
 			/* === Main Retrieval === */

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -46,7 +46,7 @@ namespace wp_kb_articles // Root namespace.
 
 				$response = $this->get_response($url);
 
-				if($response['status_code'] === 200) return json_decode($response['body'], TRUE);
+				if($response) return json_decode($response['body'], TRUE);
 				else return FALSE;
 			}
 
@@ -57,7 +57,7 @@ namespace wp_kb_articles // Root namespace.
 
 				$response = $this->get_response($url);
 
-				if($response['status_code'] === 200) return json_decode($response['body'], TRUE);
+				if($response) return json_decode($response['body'], TRUE);
 				else return FALSE;
 			}
 
@@ -68,7 +68,7 @@ namespace wp_kb_articles // Root namespace.
 
 				$response = $this->get_response($url);
 
-				if($response['status_code'] === 200) return $response['body'];
+				if($response) return $response['body'];
 				else return FALSE;
 			}
 
@@ -139,6 +139,8 @@ namespace wp_kb_articles // Root namespace.
 				$response_code = wp_remote_retrieve_response_code($request);
 
 				unset($url, $args);
+
+				if($response_code !== 302 && $response_code !== 200) return FALSE; // Error
 
 				// array('request' => $request, 'body' => $body, 'headers' => $headers, 'response_code' => $response_code);
 				return get_defined_vars();

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -176,24 +176,22 @@ namespace wp_kb_articles // Root namespace.
 			 *
 			 * @since 141111 First documented version.
 			 *
-			 * @param string $a SHA1 key or path to file
+			 * @param string $a SHA1 key or path to file.
 			 *
-			 * @return string|false
+			 * @return string|boolean String body from GitHub, else `FALSE` on error.
 			 */
 			protected function retrieve_body($a)
 			{
-				$is_sha = (bool)preg_match('/^[0-9a-f]{40}$/i', $a);
-
-				if($is_sha)
+				if(($is_sha = (boolean)preg_match('/^[0-9a-f]{40}$/i', $a)))
 				{
-					$blob = $this->retrieve_blob($a);
+					if(!($blob = $this->retrieve_blob($a)))
+						return FALSE; // Error.
 
-					if(!$blob) return FALSE;
-					if($blob['encoding'] === 'base64') return base64_decode($blob['content']);
+					if($blob['encoding'] === 'base64')
+						return base64_decode($blob['content']);
 					return $blob['content'];
 				}
-				else// It's a path
-					return $this->retrieve_file($a);
+				return $this->retrieve_file($a);
 			}
 
 			/**

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -55,11 +55,9 @@ namespace wp_kb_articles // Root namespace.
 
 					if($get_body)
 					{
-						$blob = $this->retrieve_blob($post['sha']);
+						$body = $this->retrieve_body($post['sha']);
 
-						if(!$blob) return FALSE; // TODO error handling
-
-						$body = base64_decode($blob['body']);
+						if(!$body) return FALSE; // TODO error handling
 
 						if(!strpos(trim($body), '---'))
 							$post['body'] = $body;
@@ -125,8 +123,8 @@ namespace wp_kb_articles // Root namespace.
 
 			public function retrieve_blob($sha)
 			{
-				$url = 'api.github.com/repos/%1$s/%2$s/git/trees/%3$s?recursive=1';
-				$url = sprintf($url, $this->owner, $this->repo, $this->branch);
+				$url = 'api.github.com/repos/%1$s/%2$s/git/blobs/%3$s';
+				$url = sprintf($url, $this->owner, $this->repo, $sha);
 
 				$response = $this->get_response($url);
 
@@ -167,19 +165,13 @@ namespace wp_kb_articles // Root namespace.
 			/**
 			 * Authentication
 			 *
-			 * @param        $a
-			 * @param string $b
+			 * @param string $user
+			 * @param string $pass
 			 */
-			public function authenticate($a, $b = FALSE)
+			public function authenticate($user, $pass)
 			{
-				if($b === FALSE)
-					$this->apiKey = trim($a);
-
-				else
-				{
-					$this->username = strtolower(trim($a));
-					$this->password = strtolower(trim($b));
-				}
+				$this->username = strtolower(trim((string)$user));
+				$this->password = trim((string)$pass);
 			}
 
 			/**
@@ -189,7 +181,7 @@ namespace wp_kb_articles // Root namespace.
 			{
 				// Allow for overriding of defaults
 				$_args = array('headers' => array(), 'user-agent' => apply_filters(__NAMESPACE__.'_github_api_user_agent', 'WP KB Articles for '.get_site_url()));
-				$args  = array_merge($_args, $args);
+				$args  = array_merge_recursive($_args, $args);
 				unset($_args);
 
 				// If Authorization done via GitHub API Key

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -43,10 +43,33 @@ namespace wp_kb_articles // Root namespace.
 			{
 				$url = 'api.github.com/repos/%1$s/%2$s/git/trees/%3$s?recursive=1';
 				$url = sprintf($url, $this->owner, $this->repo, $this->branch);
+
+				$response = $this->get_response($url);
+
+				if($response['status_code'] === 200) return $response['body'];
+				else return FALSE;
 			}
 
-			public function retrieve_file()
+			public function retrieve_blob($sha)
 			{
+				$url = 'api.github.com/repos/%1$s/%2$s/git/trees/%3$s?recursive=1';
+				$url = sprintf($url, $this->owner, $this->repo, $this->branch);
+
+				$response = $this->get_response($url);
+
+				if($response['status_code'] === 200) return $response['body'];
+				else return FALSE;
+			}
+
+			public function retrieve_file($file)
+			{
+				$url = 'raw.githubusercontent.com/%1$s/%2$s/%3$s/%4$s';
+				$url = sprintf($url, $this->owner, $this->repo, $this->branch, $file);
+
+				$response = $this->get_response($url);
+
+				if($response['status_code'] === 200) return $response['body'];
+				else return FALSE;
 			}
 
 			/* === Default Info === */
@@ -81,15 +104,15 @@ namespace wp_kb_articles // Root namespace.
 
 				else
 				{
-					$this->username = $a;
-					$this->password = $b;
+					$this->username = strtolower(trim($a));
+					$this->password = strtolower(trim($b));
 				}
 			}
 
 			/**
 			 * HTTP Request Method
 			 */
-			private function http($url, $args = array())
+			private function get_response($url, $args = array())
 			{
 				// Allow for overriding of defaults
 				$_args = array('headers' => array(), 'user-agent' => apply_filters(__NAMESPACE__.'_github_api_user_agent', 'WP KB Articles for '.get_site_url()));

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -20,6 +20,13 @@ namespace wp_kb_articles // Root namespace.
 		 */
 		class github_api extends abs_base
 		{
+
+			private $owner, $repo, $branch = 'HEAD';
+
+			private $apiKey, $username, $password;
+
+			public $allow_https = TRUE;
+
 			/**
 			 * Class constructor.
 			 *
@@ -28,6 +35,90 @@ namespace wp_kb_articles // Root namespace.
 			public function __construct()
 			{
 				parent::__construct();
+			}
+
+			/* === Retrieval === */
+
+			public function retrieve_tree()
+			{
+				$url = 'api.github.com/repos/%1$s/%2$s/git/trees/%3$s?recursive=1';
+				$url = sprintf($url, $this->owner, $this->repo, $this->branch);
+			}
+
+			public function retrieve_file()
+			{
+			}
+
+			/* === Default Info === */
+
+			public function set_owner($owner)
+			{
+				$this->owner = strtolower(trim($owner));
+			}
+
+			public function set_repo($repo)
+			{
+				$this->repo = strtolower(trim($repo));
+			}
+
+			public function set_branch($branch)
+			{
+				if(is_string($branch) && strlen($branch))
+					$this->branch = strtolower(trim($branch));
+				else $this->branch = 'HEAD';
+			}
+
+			/**
+			 * Authentication
+			 *
+			 * @param        $a
+			 * @param string $b
+			 */
+			public function authenticate($a, $b = FALSE)
+			{
+				if($b === FALSE)
+					$this->apiKey = trim($a);
+
+				else
+				{
+					$this->username = $a;
+					$this->password = $b;
+				}
+			}
+
+			/**
+			 * HTTP Request Method
+			 */
+			private function http($url, $args = array())
+			{
+				// Allow for overriding of defaults
+				$_args = array('headers' => array(), 'user-agent' => apply_filters(__NAMESPACE__.'_github_api_user_agent', 'WP KB Articles for '.get_site_url()));
+				$args  = array_merge($_args, $args);
+				unset($_args);
+
+				// If Authorization done via GitHub API Key
+				if($this->apiKey) $args['headers'][] = 'Authorization: token '.$this->apiKey;
+
+				// For Authorization via Username + Password
+				if(strlen($this->username) && strlen($this->password)) $before = $this->username.':'.$this->password.'@';
+				else $before = '';
+
+				// Create request URL
+				if($this->allow_https) $url = 'https://'.$before.$url;
+				else $url = 'http://'.$before.$url;
+
+				unset($before);
+
+				// Class relies on WP_Http
+				$request       = wp_remote_request($url, $args);
+				$body          = wp_remote_retrieve_body($request);
+				$headers       = wp_remote_retrieve_headers($request);
+				$response_code = wp_remote_retrieve_response_code($request);
+
+				unset($url, $args);
+
+				// array('request' => $request, 'body' => $body, 'headers' => $headers, 'response_code' => $response_code);
+				return get_defined_vars();
 			}
 		}
 	}

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -34,17 +34,21 @@ namespace wp_kb_articles // Root namespace.
 			 */
 			public function __construct(array $args)
 			{
+				parent::__construct();
+
 				$default_args = array(
 					'owner'    => '',
 					'repo'     => '',
+
 					'branch'   => 'HEAD',
+
 					'username' => '',
 					'password' => '',
-					'api_key'  => ''
-				);
 
-				$args = array_merge($default_args, $args);
-				$args = array_intersect_key($args, $default_args);
+					'api_key'  => '',
+				);
+				$args         = array_merge($default_args, $args);
+				$args         = array_intersect_key($args, $default_args);
 
 				foreach($args as $_key => $_value)
 				{

--- a/wp-kb-articles/includes/classes/github-api.php
+++ b/wp-kb-articles/includes/classes/github-api.php
@@ -37,7 +37,40 @@ namespace wp_kb_articles // Root namespace.
 				parent::__construct();
 			}
 
-			/* === Retrieval === */
+			/* === Main Retrieval === */
+
+			public function retrieve_files()
+			{
+				$tree  = $this->retrieve_tree();
+				$posts = array();
+
+				if(!$tree) return FALSE; // Error
+
+				foreach($tree['tree'] as $blob)
+				{
+					if($blob['type'] !== 'blob') continue;
+					if(!preg_match('/\.md$/i', $blob['path'])) continue;
+
+					$post = array('headers' => array(), 'body' => '', 'sha' => $blob['sha'], 'url' => $blob['url'], 'path' => $blob['path']);
+					$blob = $this->retrieve_blob($post['sha']);
+
+					if(!$blob) return FALSE; // TODO error handling
+
+					$body = base64_decode($blob['body']);
+
+					if(!strpos(trim($body), '---')) {
+						$post['body'] = $body;
+						$posts[$post['path']] = $post;
+					}
+					else {
+
+					}
+				}
+
+				return $posts;
+			}
+
+			/* === Base GitHub Retrieval === */
 
 			public function retrieve_tree()
 			{

--- a/wp-kb-articles/wp-kb-articles.php
+++ b/wp-kb-articles/wp-kb-articles.php
@@ -33,15 +33,7 @@ class wp_kb_articles // WP KB Articles; a new custom post type for WordPress.
 		wp_kb_articles::$roles_edit_caps = apply_filters('wp_kb_article_roles_edit_caps', wp_kb_articles::$roles_edit_caps);
 
 		wp_kb_articles::register();
-/*
-		require(dirname(__FILE__).'/includes/classes/github-api.php');
-
-		$that = new \wp_kb_articles\github_api;
-		$that->set_owner('brucewsinc');
-		$that->set_repo('ghpages-gen');
-
-		var_dump($that->retrieve_files());
-	*/}
+	}
 
 	public static function register()
 	{

--- a/wp-kb-articles/wp-kb-articles.php
+++ b/wp-kb-articles/wp-kb-articles.php
@@ -33,7 +33,15 @@ class wp_kb_articles // WP KB Articles; a new custom post type for WordPress.
 		wp_kb_articles::$roles_edit_caps = apply_filters('wp_kb_article_roles_edit_caps', wp_kb_articles::$roles_edit_caps);
 
 		wp_kb_articles::register();
-	}
+/*
+		require(dirname(__FILE__).'/includes/classes/github-api.php');
+
+		$that = new \wp_kb_articles\github_api;
+		$that->set_owner('brucewsinc');
+		$that->set_repo('ghpages-gen');
+
+		var_dump($that->retrieve_files());
+	*/}
 
 	public static function register()
 	{


### PR DESCRIPTION
Referencing #2

## Checklist

The class leverages the [GitHub REST API](https://developer.github.com/v3/) via [WP_Http](http://codex.wordpress.org/HTTP_API). The class only uses 3 endpoints and therefore the use of one of the (unofficial) GitHub SDK libraries has been skipped.

- [x] Ability to get a recursive list of `.md` files from a GitHub Repo
    - [x] Via the `?recursive=1` parameter in the `api.github.com` endpoint
    - [ ] Manually by recursively querying trees
- [x] Authentication
- [x] Organization/Owner & Repo Selection
- [x] Ability to download file data
    - [x] Via SHA key from tree query
    - [x] Via `path` relative to repository root
- [x] YAML header parsing
- [x] Status Code checking
    - [x] `return FALSE;` on error
    - [ ] Logging and/or debugging
- [x] docBlock Commenting

## Info

This class is reusable and can be used for multiple queries to the same, or different repositories using the same authentication method.

### Usage

```php
$git_api = new \wp_kb_articles\github_api;
$git_api->set_owner('repo_owner');
$git_api->set_repo('repo');
// $git_api->set_branch('000000-dev'); // (optional, defaults to the repo's default branch)
// $git_api->authenticate('user', 'password_or_api_key'); // (optional, will allow for up to 5000 requests, hourly, instead of 60)

// $posts = $git_api->retrieve_posts(); // To retrieve all Markdown file info without Post body or content
$posts = $git_api->retrieve_posts(true); // To retrieve all Markdown files with YAML headers and content

// $post = $git_api->retrieve_post('/path/to/file'); // To retrieve a single Post
```